### PR TITLE
fix(ticks): ticks interval issue on short duration extending effects

### DIFF
--- a/EventHorizon/Core/Database.lua
+++ b/EventHorizon/Core/Database.lua
@@ -23,7 +23,7 @@ EventHorizon.defaults = {
 		locked = false,
 		combat = false,
 		channels = {},
-		dots = {},
+		debuffs = {},
 		directs = {}
 	}
 }

--- a/EventHorizon/Frame/MainFrame.lua
+++ b/EventHorizon/Frame/MainFrame.lua
@@ -63,7 +63,7 @@ function MainFrame:AddDirectSpellFrame(spellId, enabled, order)
 	self:AddSpellFrame(spellFrame)
 end
 
-function MainFrame:AddDotSpellFrame(spellId, enabled, order)
+function MainFrame:AddDebuffSpellFrame(spellId, enabled, order)
 	local spellFrame = self:RemoveSpellFrame(spellId)
 
 	if not spellFrame then
@@ -113,8 +113,8 @@ function MainFrame:LoadSpellFrames()
 		self:AddDirectSpellFrame(spell.spellId, spell.enabled, spell.order)
 	end
 
-	for _,spell in pairs(EventHorizon.opt.dots) do
-		self:AddDotSpellFrame(spell.spellId, spell.enabled, spell.order)
+	for _,spell in pairs(EventHorizon.opt.debuffs) do
+		self:AddDebuffSpellFrame(spell.spellId, spell.enabled, spell.order)
 	end
 end
 

--- a/EventHorizon/Indicator/CastedDebuffIndicator.lua
+++ b/EventHorizon/Indicator/CastedDebuffIndicator.lua
@@ -13,8 +13,8 @@ setmetatable(CastedDebuffIndicator, {
   end,
 })
 
-function CastedDebuffIndicator:new(target, start, stop, numTicks, spellId)
-	DebuffIndicator.new(self, target, start, stop, numTicks)
+function CastedDebuffIndicator:new(target, start, stop, spellId)
+	DebuffIndicator.new(self, target, start, stop, spellId)
 	
 	self.style.point1 = {'TOP', 'TOP', 0, -3}
 	self.style.point2 = {'BOTTOM', 'TOP', -3, -6}

--- a/EventHorizon/Indicator/DebuffIndicator.lua
+++ b/EventHorizon/Indicator/DebuffIndicator.lua
@@ -22,9 +22,10 @@ function DebuffIndicator:new(target, start, stop, numTicks)
 	self.numTicks = numTicks
 
 	local duration = stop - start
-	local interval = duration / numTicks
+	self.snapInterval = duration / numTicks
+
 	for i=1,numTicks do
-		local tick = TickIndicator(target, start + i*interval)
+		local tick = TickIndicator(target, start + i*self.snapInterval)
 		tinsert(self.ticks, tick)
 	end
 end
@@ -53,10 +54,8 @@ function DebuffIndicator:Refresh(start, stop)
 end	
 
 function DebuffIndicator:ApplyTicksAfter(start, stop, lastTick)
-	local duration = stop - start
-	local interval = duration / self.numTicks
 	for i=1,self.numTicks do
-		local tickTime = lastTick + i*interval
+		local tickTime = lastTick + i*self.snapInterval
 		if tickTime <= stop then
 			local tick = TickIndicator(self.target, tickTime)
 			tinsert(self.ticks, tick)

--- a/EventHorizon/Indicator/DebuffIndicator.lua
+++ b/EventHorizon/Indicator/DebuffIndicator.lua
@@ -18,19 +18,17 @@ function DebuffIndicator:new(target, start, stop, spellId)
 	self.style.texture = EventHorizon.opt.debuff
 	self.style.ready = EventHorizon.opt.ready
 
-	
 	self.spellId = spellId
 	self.spellName = GetSpellInfo(spellId)
 	
 	self.ticks = {}
 
-
 	if EventHorizon.opt.debuffs[self.spellName].dot then		
 		self.numTicks = EventHorizon.opt.debuffs[self.spellName].ticks
 		local duration = stop - start
-		local interval = duration / self.numTicks
+		self.snapInterval = duration / self.numTicks
 		for i=1,self.numTicks do
-			local tick = TickIndicator(target, start + i*interval)
+			local tick = TickIndicator(target, start + i*self.snapInterval)
 			tinsert(self.ticks, tick)
 		end
 	end
@@ -71,10 +69,8 @@ function DebuffIndicator:Refresh(start, stop)
 end	
 
 function DebuffIndicator:ApplyTicksAfter(start, stop, lastTick)
-	local duration = stop - start
-	local interval = duration / self.numTicks
 	for i=1,self.numTicks do
-		local tickTime = lastTick + i*interval
+		local tickTime = lastTick + i*self.snapInterval
 		if tickTime <= stop then
 			local tick = TickIndicator(self.target, tickTime)
 			tinsert(self.ticks, tick)

--- a/EventHorizon/Spell/Debuffer.lua
+++ b/EventHorizon/Spell/Debuffer.lua
@@ -29,12 +29,11 @@ end
 
 function Debuffer:GenerateDebuff(target, start, stop)	
 	local debuff
-	local ticks = EventHorizon.opt.dots[self.spellName].ticks
 	if self.casted then		
-		debuff = CastedDebuffIndicator(target, start, stop, ticks, self.spellId)
+		debuff = CastedDebuffIndicator(target, start, stop, self.spellId)
 		tinsert(self.indicators, debuff.recast)
 	else
-		debuff = DebuffIndicator(target, start, stop, ticks)		
+		debuff = DebuffIndicator(target, start, stop, self.spellId)		
 	end
 
 	tinsert(self.indicators, debuff)


### PR DESCRIPTION
Debuff duration extending side effects (e.g druid shred glyph) that adds a duration shorter than the spell original duration results in additionally applied ticks getting an incorrect interval. 

Sanity performed on priest, rogue, warrior, hunter, druid after the change.