### PR TITLE
fix(buffs): fix player unit buffs hidden when targeting units

### DIFF
--- a/EventHorizon/Indicator/Indicator.lua
+++ b/EventHorizon/Indicator/Indicator.lua
@@ -21,6 +21,7 @@ function Indicator:new(target, start, stop)
 	self.original = {start=start,stop=stop}
 
 	self.disposed = false	
+	self.alwaysShow = false
 
 	self.style = {
 		texture = {1,1,1,1},
@@ -48,6 +49,8 @@ function Indicator:GetPoints()
 end
 
 function Indicator:IsVisible()
+	if self.alwaysShow then return true end
+
 	local target = UnitGUID('target')
 	local dead = UnitIsDead('target')
 

--- a/EventHorizon/Spell/Buffer.lua
+++ b/EventHorizon/Spell/Buffer.lua
@@ -28,6 +28,10 @@ end
 
 function Buffer:GenerateBuff(target, start, stop)	
 	local buff = AuraIndicator(target, start, stop, self.spellId, EventHorizon.opt.buff, EventHorizon.opt.buffs[self.spellName])
+	
+	if EventHorizon.opt.buffs[self.spellName].unitId == 'player' then
+		buff.alwaysShow = true
+	end
 
 	if buff.casted then
 		tinsert(self.indicators, buff.recast)
@@ -91,6 +95,11 @@ end
 
 function Buffer:RemoveBuff(target)
 	self.buffs[target] = nil
+	-- manually stop indicators since self buffs can be right-clicked
+	local now = GetTime()
+	for _,indicator in pairs(self.indicators) do
+		indicator:Stop(now)
+	end
 end
 
 function Buffer:ClearIndicator(indicator)

--- a/EventHorizon/Spell/Buffer.lua
+++ b/EventHorizon/Spell/Buffer.lua
@@ -29,9 +29,7 @@ end
 function Buffer:GenerateBuff(target, start, stop)	
 	local buff = AuraIndicator(target, start, stop, self.spellId, EventHorizon.opt.buff, EventHorizon.opt.buffs[self.spellName])
 	
-	if EventHorizon.opt.buffs[self.spellName].unitId == 'player' then
-		buff.alwaysShow = true
-	end
+	buff.alwaysShow = EventHorizon.opt.buffs[self.spellName].unitId == 'player'
 
 	if buff.casted then
 		tinsert(self.indicators, buff.recast)
@@ -95,10 +93,12 @@ end
 
 function Buffer:RemoveBuff(target)
 	self.buffs[target] = nil
-	-- manually stop indicators since self buffs can be right-clicked
+	-- manually stop indicators since buffs can be right-clicked or dispelled
 	local now = GetTime()
 	for _,indicator in pairs(self.indicators) do
-		indicator:Stop(now)
+   	    if indicator.target == target then
+		    indicator:Stop(now)
+	    end 
 	end
 end
 

--- a/EventHorizon/Spell/Debuffer.lua
+++ b/EventHorizon/Spell/Debuffer.lua
@@ -106,6 +106,13 @@ end
 
 function Debuffer:RemoveDebuff(target)
 	self.debuffs[target] = nil
+	-- manually stop indicators since debuffs can be right-clicked or dispelled
+	local now = GetTime()
+	for _,indicator in pairs(self.indicators) do
+   	    if indicator.target == target then
+		    indicator:Stop(now)
+	    end 
+	end
 end
 
 function Debuffer:ClearIndicator(indicator)


### PR DESCRIPTION
* Added `self.alwaysShow` property to Indicator affecting `Indicator:IsVisible()` and set by `Buffer:GenerateBuff()`
* `Buffer:RemoveBuff` now also stops any indicator since buffs can be right-clicked for premature buff cancellation interaction