### PR TITLE
fix(buffs/debuffs): buff/debuff removal bug fix

### DIFF
--- a/EventHorizon/Indicator/AuraIndicator.lua
+++ b/EventHorizon/Indicator/AuraIndicator.lua
@@ -163,11 +163,18 @@ function AuraIndicator:ApplyTicksAfter(start, stop, lastTick)
 	end
 end
 
-function AuraIndicator:RemoveTicksAfter(time)
+function AuraIndicator:RemoveTicksAfter(point)
+	-- lastTickProximiySec: Align the last remaining tick with proximity to the stop stop
+	-- (cosmetics due to server internal jitter)
+	local lastTickProximitySec = 0.2
+
 	for i=#self.ticks,1,-1 do
-		local diff = self.ticks[i].start - time
-		if diff > 0.1 then
+		local proximity = math.abs(self.ticks[i].start - point)
+		if self.ticks[i].start > point + lastTickProximitySec then
 			tremove(self.ticks,i):Dispose()
+		elseif proximity < lastTickProximitySec then
+			self.ticks[i].stop = point
+			self.ticks[i].start = point
 		end
 	end
 end

--- a/EventHorizon/Spell/Debuffer.lua
+++ b/EventHorizon/Spell/Debuffer.lua
@@ -105,14 +105,21 @@ function Debuffer:CaptureDebuff(target, start)
 end
 
 function Debuffer:RemoveDebuff(target)
-	self.debuffs[target] = nil
-	-- manually stop indicators since debuffs can be right-clicked or dispelled
-	local now = GetTime()
-	for _,indicator in pairs(self.indicators) do
-   	    if indicator.target == target then
-		    indicator:Stop(now)
-	    end 
+	-- manually stop indicators (once) since debuffs can be right-clicked or dispelled
+	if self.debuffs[target] then
+		local now = GetTime()
+		for i=#self.indicators,1,-1 do
+			local indicator = self.indicators[i]
+			if indicator and indicator.target == target then
+				if indicator.start < indicator.stop then
+					indicator:Stop(now)
+				elseif indicator.start == indicator.stop and indicator.start > now + 0.1 then -- a future tick indicator (100ms grace)
+					tremove(self.indicators,i):Dispose()
+				end
+			end 
+		end
 	end
+	self.debuffs[target] = nil
 end
 
 function Debuffer:ClearIndicator(indicator)


### PR DESCRIPTION
Fixes a bug introduced with the last build.
Fix does two things:
1) Make sure we are stopping indicators only once since subsequent UNIT_AURA events during the "past" window can cause the indicator's end to jump back to "now" since the Stop call is with GetTime
2) Dispose ticks after. It is a bit weird doing this from the Parent class though but the tick indicators are referenced by the parent.

Anyways, I don't like this so much.