### PR TITLE
fix(auras,removal): fixed removed auras sometimes showing after expiration and ticks not showing

### DIFF
--- a/EventHorizon/Indicator/AuraIndicator.lua
+++ b/EventHorizon/Indicator/AuraIndicator.lua
@@ -163,11 +163,18 @@ function AuraIndicator:ApplyTicksAfter(start, stop, lastTick)
 	end
 end
 
-function AuraIndicator:RemoveTicksAfter(time)
+function AuraIndicator:RemoveTicksAfter(point)
+	-- lastTickProximiySec: Align the last remaining tick with proximity to the stop stop
+	-- (cosmetics due to server internal jitter)
+	local lastTickProximitySec = 0.2
+
 	for i=#self.ticks,1,-1 do
-		local diff = self.ticks[i].start - time
-		if diff > 0.1 then
+		local proximity = math.abs(self.ticks[i].start - point)
+		if self.ticks[i].start > point + lastTickProximitySec then
 			tremove(self.ticks,i):Dispose()
+		elseif proximity < lastTickProximitySec then
+			self.ticks[i].stop = point
+			self.ticks[i].start = point
 		end
 	end
 end

--- a/EventHorizon/Spell/Debuffer.lua
+++ b/EventHorizon/Spell/Debuffer.lua
@@ -105,14 +105,21 @@ function Debuffer:CaptureDebuff(target, start)
 end
 
 function Debuffer:RemoveDebuff(target)
-	self.debuffs[target] = nil
-	-- manually stop indicators since debuffs can be right-clicked or dispelled
-	local now = GetTime()
-	for _,indicator in pairs(self.indicators) do
-   	    if indicator.target == target then
-		    indicator:Stop(now)
-	    end 
+	-- manually stop indicators (once) since debuffs can be right-clicked or dispelled
+	if self.debuffs[target] then
+		local now = GetTime()
+		for i=#self.indicators,1,-1 do
+			local indicator = self.indicators[i]
+			if indicator and indicator.target == target then
+				if indicator.start < indicator.stop then
+					indicator:Stop(now)
+				elseif indicator.start == indicator.stop and indicator.start > now + 0.1 then -- a future tick indicator (100ms grace)
+					tremove(self.indicators,i):Dispose()
+				end
+			end 
+		end
 	end
+	self.debuffs[target] = nil
 end
 
 function Debuffer:ClearIndicator(indicator)


### PR DESCRIPTION
* Fixed a bug introduced in last aura removal changes that caused buffs/debuffs to keep jumping to "now" when UNIT_AURA is triggered, Basically making sure removal is happening only once since upstream CheckTargetDebuff is removing buffs eagerly.

* Added future ticks disposal in Debuffer/Buffer since they hold a reference to ticks inside AuraIndicator and keeps showing when aura is cancelled/dispelled

* Pushed `alwaysShow` also to tick indicators for `player` buffs since they were not showing unless the player targets himself.