### PR TITLE
fix(textures): bumped reference lines to be on top of spell textures

### DIFF
--- a/EventHorizon/Frame/MainFrame.lua
+++ b/EventHorizon/Frame/MainFrame.lua
@@ -255,7 +255,7 @@ function MainFrame:UpdateAllFrames()
 	if self.nowReference then
 		self.nowReference
 		:GetTexture()
-		:SetPoint('TOPLEFT',self.frame,'TOPLEFT', -past/(future-past)*width, 0)	
+		:SetPoint('TOPLEFT',self.frame,'TOPLEFT', -past/(future-past)*width, -1)	
 
 		self.nowReference
 		:GetTexture()
@@ -265,7 +265,7 @@ function MainFrame:UpdateAllFrames()
 	if self.gcdReference then
 		self.gcdReference
 		:GetTexture()
-		:SetPoint('TOP',self.frame,'TOP', -past/(future-past)*width-0.5+height, 0)	
+		:SetPoint('TOP',self.frame,'TOP', -past/(future-past)*width-0.5+height, -1)	
 
 		self.gcdReference
 		:GetTexture()

--- a/EventHorizon/Frame/MainFrameBuilder.lua
+++ b/EventHorizon/Frame/MainFrameBuilder.lua
@@ -13,7 +13,8 @@ function MainFrameBuilder:new()
 	self.frame = CreateFrame("Frame", "EventHorizon", UIParent, "BackdropTemplate")	
 	local texture = EventHorizon.media:Fetch("background", EventHorizon.opt.texture)
 	self.frame:SetBackdrop({edgeFile=texture, edgeSize=1})
-	self.frame:SetBackdropBorderColor(unpack(EventHorizon.opt.border))	
+	self.frame:SetBackdropBorderColor(unpack(EventHorizon.opt.border))
+	self.frame:SetFrameLevel(100)	
 end
 
 function MainFrameBuilder:WithHandle()

--- a/EventHorizon/Frame/SpellFrameBuilder.lua
+++ b/EventHorizon/Frame/SpellFrameBuilder.lua
@@ -20,6 +20,7 @@ function SpellFrameBuilder:new(framePool, spellId, enabled, order)
 	local texture = EventHorizon.media:Fetch("statusbar", EventHorizon.opt.texture)
 	self.frame:SetBackdrop({bgFile=texture})
 	self.frame:SetBackdropColor(unpack(EventHorizon.opt.background))	
+	self.frame:SetFrameLevel(10)	
 
 
 end

--- a/EventHorizon/Reference/Reference.lua
+++ b/EventHorizon/Reference/Reference.lua
@@ -12,8 +12,8 @@ setmetatable(Reference, {
 function Reference:new(frame)
 	self.frame = frame
 
-	self.texture = self.frame:CreateTexture(nil, 'BORDER')
-	self.texture:SetPoint('BOTTOM',self.frame,'BOTTOM')
+	self.texture = self.frame:CreateTexture(nil, 'OVERLAY')
+	self.texture:SetPoint('BOTTOM',self.frame,'BOTTOM', 0, 1)
 	self.texture:SetWidth(1)
 end
 


### PR DESCRIPTION
Also add a top and bottom pixel adjust so reference lines are not on top of the visible border