### PR TITLE
Add spell icon zoom option

### DIFF
--- a/EventHorizon/Core/Database.lua
+++ b/EventHorizon/Core/Database.lua
@@ -31,6 +31,7 @@ EventHorizon.defaults = {
 		channels = {},
 		debuffs = {},
 		buffs = {},
+		zoom = 0,
 	}
 }
 

--- a/EventHorizon/Core/Options.lua
+++ b/EventHorizon/Core/Options.lua
@@ -222,10 +222,12 @@ function EventHorizon:CreateGlobalOptions()
 				inline = true,
 				args = {
 					zoom = {
-						name = "Spell Icon Zoom",
-						desc = "Remove borders from spell icons",
-						type = "toggle",
-						width = 1.0,
+						name = "Spell Icon Zoom %",
+						desc = "Zoom in on spell icons so that the grey borders can be cropped out",
+						type = "range",
+						min = 0,
+						max = 50,
+						step = 1,
 						order = 1,
 						get = function(info) return EventHorizon.opt.zoom end,
 						set = function(info, val) EventHorizon.opt.zoom = val EventHorizon:RefreshMainFrame() end

--- a/EventHorizon/Core/Options.lua
+++ b/EventHorizon/Core/Options.lua
@@ -221,6 +221,15 @@ function EventHorizon:CreateGlobalOptions()
 				type = "group",
 				inline = true,
 				args = {
+					zoom = {
+						name = "Spell Icon Zoom",
+						desc = "Remove borders from spell icons",
+						type = "toggle",
+						width = 1.0,
+						order = 1,
+						get = function(info) return EventHorizon.opt.zoom end,
+						set = function(info, val) EventHorizon.opt.zoom = val EventHorizon:RefreshMainFrame() end
+					},
 					width = {
 						name = "Width",
 						type = "range",
@@ -228,7 +237,7 @@ function EventHorizon:CreateGlobalOptions()
 						min = 1,
 						max = 500,
 						step = 1,
-						order = 1,
+						order = 2,
 						get = function(info) return EventHorizon.opt.width end,
 						set = function(info,val) EventHorizon:SetWidth(val) end
 					},				
@@ -239,11 +248,11 @@ function EventHorizon:CreateGlobalOptions()
 						min = 1,
 						max = 50,
 						step = 1,
-						order = 2,
+						order = 3,
 						get = function(info) return EventHorizon.opt.height end,
 						set = function(info,val) EventHorizon:SetHeight(val) end
 					}
-				}			
+				}
 			},
 			timeLine = {
 				order = 4,

--- a/EventHorizon/Frame/MainFrame.lua
+++ b/EventHorizon/Frame/MainFrame.lua
@@ -302,11 +302,11 @@ function MainFrame:UpdateAllFrames()
 			spellFrame
 			:GetIcon()
 			:SetSize(height, height)
-			if EventHorizon.opt.zoom then
-				spellFrame:GetIcon():SetTexCoord(.08, .92, .08, .92)
-			else
-				spellFrame:GetIcon():SetTexCoord(0, 1, 0, 1)
-			end
+			
+			local coordScale = (EventHorizon.opt.zoom) / 100
+			spellFrame
+			:GetIcon()
+			:SetTexCoord(0 + coordScale, 1 - coordScale, 0 + coordScale, 1 -coordScale)
 		end
 
 		if i > 1 then

--- a/EventHorizon/Frame/MainFrame.lua
+++ b/EventHorizon/Frame/MainFrame.lua
@@ -303,7 +303,12 @@ function MainFrame:UpdateAllFrames()
 			:GetIcon()
 			:SetSize(height, height)
 			
-			local coordScale = (EventHorizon.opt.zoom) / 100
+			local coordScale
+			if EventHorizon.opt.zoom ~= nil then
+				coordScale = EventHorizon.opt.zoom / 100
+			else
+				coordScale = 1
+			end
 			spellFrame
 			:GetIcon()
 			:SetTexCoord(0 + coordScale, 1 - coordScale, 0 + coordScale, 1 -coordScale)

--- a/EventHorizon/Frame/MainFrame.lua
+++ b/EventHorizon/Frame/MainFrame.lua
@@ -302,6 +302,11 @@ function MainFrame:UpdateAllFrames()
 			spellFrame
 			:GetIcon()
 			:SetSize(height, height)
+			if EventHorizon.opt.zoom then
+				spellFrame:GetIcon():SetTexCoord(.08, .92, .08, .92)
+			else
+				spellFrame:GetIcon():SetTexCoord(0, 1, 0, 1)
+			end
 		end
 
 		if i > 1 then


### PR DESCRIPTION
Provide an option to 'zoom' the spell icons (globally) of spell frames, removing the grey borders