### PR TITLE
fix(options): generic spell creation bug

### DIFF
--- a/EventHorizon/Core/Options/BuffOptions.lua
+++ b/EventHorizon/Core/Options/BuffOptions.lua
@@ -62,7 +62,7 @@ function EventHorizon:CreateNewBuffSpell()
 			end
 		end
 	end
-	if spellName and not self.opt.buffs[spellName] then
+	if spellName and not self.opt.buffs[spellName].spellId then
 		local buff = {
 			spellId=spellId, 
 			unitId="player", 

--- a/EventHorizon/Core/Options/CastOptions.lua
+++ b/EventHorizon/Core/Options/CastOptions.lua
@@ -44,7 +44,7 @@ end
 function EventHorizon:CreateNewCastedSpell()
 	local spellName,_,_,_,_,_,spellId = GetSpellInfo(EventHorizon.newCastedSpell)
 
-	if spellName and not self.opt.casts[spellName] then
+	if spellName and not self.opt.casts[spellName].spellId then
 		local cast = {
 			spellId=spellId, 
 			enabled=true, 

--- a/EventHorizon/Core/Options/ChannelOptions.lua
+++ b/EventHorizon/Core/Options/ChannelOptions.lua
@@ -3,7 +3,7 @@ local GetSpellInfo = GetSpellInfo
 function EventHorizon:CreateNewChanneledSpell()	
 	local spellName,_,_,_,_,_,spellId = GetSpellInfo(EventHorizon.newChannelSpell)
 
-	if spellName and not self.opt.channels[spellName] then
+	if spellName and not self.opt.channels[spellName].spellId then
 		local channel = {
 			spellId=spellId, 
 			ticks=1, 

--- a/EventHorizon/Core/Options/DebuffOptions.lua
+++ b/EventHorizon/Core/Options/DebuffOptions.lua
@@ -64,7 +64,7 @@ function EventHorizon:CreateNewDebuffSpell()
 			end
 		end
 	end
-	if spellName and not self.opt.debuffs[spellName] then
+	if spellName and not self.opt.debuffs[spellName].spellId then
 		local debuff = {
 			spellId=spellId, 
 			ticks=false, 


### PR DESCRIPTION
due to default values from Database.lua in buffs/debuffs/channels/casts, spell existence checks on specc creation functions always returns true. resulting in various errors.