### PR TITLE
fix(corruption): corruption refresh edge cases

### DIFF
--- a/EventHorizon/Spell/Debuffer.lua
+++ b/EventHorizon/Spell/Debuffer.lua
@@ -81,7 +81,7 @@ function Debuffer:WasRefreshed(debuff, lastSuccess, start, stop)
 		end
 
 		-- try to detect a cast, casts do not refresh dots
-		if abs(start - lastSuccess) < 0.5 then
+		if abs(start - lastSuccess) < 0.25 then
 			return false
 		end
 	else


### PR DESCRIPTION
* Handle a corruption refresh before the first tick edge case
* Added Corruption spell name localization
* Reduced cast detection in WasRefreshed from 500ms to 250ms since abilities with travel time that can refresh an aura can result in EH incorrectly assumes a cast was done in a scenario of: "Cast refreshing ability with travel time" -> "Cast the dot" -> "Ability hits boss very shortly after the dot apply and refreshes it" -> EH thinks the ability was casted again